### PR TITLE
Require `rails-data-migrations` explicitly

### DIFF
--- a/lib/generators/data_migration_generator.rb
+++ b/lib/generators/data_migration_generator.rb
@@ -1,4 +1,5 @@
 require 'rails/generators'
+require 'rails-data-migrations'
 
 class DataMigrationGenerator < Rails::Generators::NamedBase
   source_root File.expand_path('../templates', __FILE__)


### PR DESCRIPTION
Without this require, it will fail when used with rails engine.