### PR TITLE
adds rake data:reset

### DIFF
--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -24,6 +24,16 @@ namespace :data do
     end
   end
 
+  desc 'Mark all pending data migrations complete'
+  task reset: :init_migration do
+    source_versions = RailsDataMigrations::Migrator.migrations(migrations_path).collect(&:version)
+    applied_versions = RailsDataMigrations::Migrator.get_all_versions
+
+    (source_versions - applied_versions).sort.each do |version|
+      RailsDataMigrations::LogEntry.create!(version: version.to_s)
+    end
+  end
+
   namespace :migrate do
     desc 'Apply single data migration using VERSION'
     task up: :init_migration do

--- a/spec/data_migrations_spec.rb
+++ b/spec/data_migrations_spec.rb
@@ -75,5 +75,14 @@ describe RailsDataMigrations do
       expect { Rake::Task['data:migrate:up'].execute}.to raise_error(RuntimeError, 'VERSION is required')
       expect { Rake::Task['data:migrate:down'].execute}.to raise_error(RuntimeError, 'VERSION is required')
     end
+
+    it 'marks pending migrations complete without running them' do
+      load_rake_rasks
+
+      allow(RailsDataMigrations::Migrator).to receive(:run) { true }
+      Rake::Task['data:reset'].execute
+      expect(RailsDataMigrations::LogEntry.count).to eq(1)
+      expect(RailsDataMigrations::Migrator).not_to have_received(:run)
+    end
   end
 end


### PR DESCRIPTION
- This task marks all pending data migrations complete, without actually
running them. This can be useful when deploying to a new server,
following rake db:schema:load
- Closes #6