### PR TITLE
Add pre migrations to allow more control of when data migrations can …

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,31 @@ rake data:migrate
  
 This will run all pending data migrations and store migration history in `data_migrations` table. You're all set.
 
+If you need to generate migrations that can be run separately from data_migrations you can create Pre Migrations
+
+To create a pre data migration you need to run:
+```
+rails generate pre_data_migration migration_name
+```
+
+and this will create a `pre_migration_name.rb` file in `db/data_migrations` folder with a following content:
+```ruby
+class PreMigrationName < DataMigration
+  def up
+    # put your code here
+  end
+end
+```
+ 
+so all we need to do is to put some ruby code inside the `up` method.
+ 
+Finally, at the release time, you need to run 
+```
+rake data:migrate:pre
+```
+ 
+This will run all pending pre data migrations and store migration history in `data_migrations` table. You're all set.
+
 ## Rails Support
 
 Rails 4.0 and higher

--- a/lib/generators/pre_data_migration_generator.rb
+++ b/lib/generators/pre_data_migration_generator.rb
@@ -1,0 +1,14 @@
+require 'rails/generators'
+require 'rails-data-migrations'
+
+class PreDataMigrationGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('../templates', __FILE__)
+
+  def create_migration_file
+    migration_file_name =
+      "#{RailsDataMigrations::Migrator.migrations_path}/#{Time.now.utc.strftime('%Y%m%d%H%M%S')}_pre_#{file_name}.rb"
+    copy_file 'data_migration_generator.rb', migration_file_name do |content|
+      content.sub(/ClassName/, "Pre#{file_name.camelize}")
+    end
+  end
+end

--- a/lib/rails_data_migrations/migrator.rb
+++ b/lib/rails_data_migrations/migrator.rb
@@ -53,9 +53,22 @@ module RailsDataMigrations
       def list_pending_migrations
         if rails_5_2?
           already_migrated = get_all_versions
-          list_migrations.reject { |m| already_migrated.include?(m.version) }
+          list_migrations
+            .reject { |m| already_migrated.include?(m.version) }
+            .reject { |m| m.filename.match(/\d{14}_pre_/) }
         else
-          open(migrations_path).pending_migrations
+          open(migrations_path).pending_migrations.reject { |m| m.filename.match(/\d{14}_pre_/) }
+        end
+      end
+
+      def list_pending_pre_migrations
+        if rails_5_2?
+          already_migrated = get_all_versions
+          list_migrations
+            .reject { |m| already_migrated.include?(m.version) }
+            .select { |m| m.filename.match(/\d{14}_pre_/) }
+        else
+          open(migrations_path).pending_migrations.select { |m| m.filename.match(/\d{14}_pre_/) }
         end
       end
 

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -34,6 +34,13 @@ namespace :data do
       apply_single_migration(:up, ENV['VERSION'])
     end
 
+    desc 'Apply pre data migrations'
+    task pre: :init_migration do
+      RailsDataMigrations::Migrator.list_pending_pre_migrations.sort_by(&:version).each do |m|
+        apply_single_migration(:up, m.version)
+      end
+    end
+
     desc 'Revert single data migration using VERSION'
     task down: :init_migration do
       apply_single_migration(:down, ENV['VERSION'])


### PR DESCRIPTION
…be run

I love using your gem but need a little more control of when to run data migrations. Sometimes I need to run data migrations after a rails migration to update the structure of the database. Sometimes I need to run data migrations before a rails migration because I am dropping a table and need to delete extra records and cleanup. I am introducing the concept of a Pre Migration that can be controlled separately if desired but will also execute in the normal flow just like a normal data migration. My thought was to update my deployment pipeline to execute this flow and then I should be able to create either a normal or pre data migration to satisfy all cases.

```
rails data:migrate:pre
rails db:migrate
rails data:migrate
```

I am open to other names for that other type of migration (Pre Migration) but wanted to facilitate a way to run data migrations a different way based on file name so that my pipeline does not have to change.

I ran the tests using `rspec` but was not able to get the tests to run using `appraisal install && appraisal rake`